### PR TITLE
Change naming: `levelSuffixes` to `levelPrefixes`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ logger.info('Hello info!');
 // -> 👻 INFO  2018-12-16 21:50:03.562583 [example/simple_logger_example.dart 29:10 in main] Hello info!
 
 // Customize level prefix
-logger.levelSuffixes = {};
+logger.levelPrefixes = {};
 logger.info('Hello info!');
 // -> INFO  2018-12-16 21:50:03.562583 [example/simple_logger_example.dart 29:10 in main] Hello info!
 

--- a/example/simple_logger_example.dart
+++ b/example/simple_logger_example.dart
@@ -35,7 +35,7 @@ void main() {
   // -> 👻 INFO  2018-12-16 21:50:03.562583 [example/simple_logger_example.dart 29:10 in main] Hello info!
 
   // Customize level prefix
-  logger.levelSuffixes = {};
+  logger.levelPrefixes = {};
   logger.info('Hello info!');
   // -> INFO  2018-12-16 21:50:03.562583 [example/simple_logger_example.dart 29:10 in main] Hello info!
 

--- a/lib/src/simple_logger.dart
+++ b/lib/src/simple_logger.dart
@@ -68,14 +68,14 @@ class SimpleLogger {
     _includeCallerInfo = includeCallerInfo;
   }
 
-  /// Customize level suffix by changing this.
+  /// Customize level prefix by changing this.
   ///
-  /// ### Suffix can be omitted.
+  /// ### Prefix can be omitted.
   ///
   /// ```
-  /// logger.levelSuffixes = {};
+  /// logger.levelPrefixes = {};
   /// ```
-  var levelSuffixes = {
+  var levelPrefixes = {
     Level.FINEST: '👾 ',
     Level.FINER: '👀 ',
     Level.FINE: '🎾 ',
@@ -107,7 +107,7 @@ class SimpleLogger {
       case LoggerMode.log:
         return '';
       case LoggerMode.print:
-        return '${levelSuffixes[level] ?? ''}$level ';
+        return '${levelPrefixes[level] ?? ''}$level ';
     }
     assert(false);
     return '';

--- a/test/simple_logger_test.dart
+++ b/test/simple_logger_test.dart
@@ -10,7 +10,7 @@ void main() {
       expect(target.isLoggable(Level.FINE), false);
       expect(target.isLoggable(Level.SHOUT), true);
       expect(target.formatter, null);
-      expect(target.levelSuffixes.isNotEmpty, true);
+      expect(target.levelPrefixes.isNotEmpty, true);
       expect(target.includeCallerInfo, false);
 
       target.info('test');


### PR DESCRIPTION
Hi!

I thought naming of property "`levelSuffix`" should be "`levelPrefix`", so I fixed it.
I also ran unit testing After changed. Then it passed.

Could you review this p-r?