### PR TITLE
Change stackTraceEnabled in the document to includeCallerInfo

### DIFF
--- a/lib/src/simple_logger.dart
+++ b/lib/src/simple_logger.dart
@@ -53,7 +53,7 @@ class SimpleLogger {
   /// If includeCallerInfo is true, caller info will be included for
   /// any message of this level or above automatically.
   /// Because this is expensive, this is false by default.
-  /// So, setting stackTraceEnabled to true for only debug build is recommended.
+  /// So, setting includeCallerInfo to true for only debug build is recommended.
   ///
   /// ### Example
   ///


### PR DESCRIPTION
Thanks for the great package!

Perhaps the old word stackTraceEnabled was still there, so I changed it to includeCallerInfo.